### PR TITLE
Add rtpjitterbuffer to sync USB camera Audio and Video

### DIFF
--- a/src/streaming/streaming-receiver.cpp
+++ b/src/streaming/streaming-receiver.cpp
@@ -22,16 +22,18 @@ int main(int argc, char *argv[])
     GstElement *audio_sink = gst_element_factory_make("autoaudiosink", "audio_sink");
 
     GstElement *video_source = gst_element_factory_make("udpsrc", "video_source");
-    g_object_set(video_source, "port", 7002, "caps", gst_caps_from_string("application/x-rtp,media=(string)video"), NULL);
+    g_object_set(video_source, "port", 7002, "caps", gst_caps_from_string("application/x-rtp"), NULL);
+    GstElement *video_rtp_jitter_buffer = gst_element_factory_make("rtpjitterbuffer", "video_rtp_jitter_buffer");
+    g_object_set(video_rtp_jitter_buffer, "mode", 1, "do-retransmission", TRUE, "drop-on-latency", TRUE, "latency", 1000, NULL);
     GstElement *video_depay = gst_element_factory_make("rtph264depay", "video_depay");
     GstElement *video_decode = gst_element_factory_make("avdec_h264", "video_decode");
     GstElement *video_convert = gst_element_factory_make("videoconvert", "video_convert");
     GstElement *video_queue = gst_element_factory_make("queue", "video_queue");
     GstElement *video_sink = gst_element_factory_make("autovideosink", "video_sink");
 
-    gst_bin_add_many(GST_BIN(pipeline), audio_source, audio_depay, audio_decode, audio_convert, audio_queue, audio_sink, video_source, video_depay, video_decode, video_convert, video_queue, video_sink, NULL);
+    gst_bin_add_many(GST_BIN(pipeline), audio_source, audio_depay, audio_decode, audio_convert, audio_queue, audio_sink, video_source, video_rtp_jitter_buffer, video_depay, video_decode, video_convert, video_queue, video_sink, NULL);
     gst_element_link_many(audio_source, audio_depay, audio_decode, audio_convert, audio_queue, audio_sink, NULL);
-    gst_element_link_many(video_source, video_depay, video_decode, video_convert, video_queue, video_sink, NULL);
+    gst_element_link_many(video_source, video_rtp_jitter_buffer, video_depay, video_decode, video_convert, video_queue, video_sink, NULL);
 
     GstBus *bus = gst_pipeline_get_bus(GST_PIPELINE(pipeline));
     gst_bus_add_watch(bus, gst_bus_call, loop);

--- a/src/streaming/streaming-receiver.cpp
+++ b/src/streaming/streaming-receiver.cpp
@@ -16,7 +16,7 @@ int main(int argc, char *argv[])
     GstElement *audio_source = gst_element_factory_make("udpsrc", "audio_source");
     g_object_set(audio_source, "port", 7001, "caps", gst_caps_from_string("application/x-rtp"), NULL);
     GstElement *audio_rtp_jitter_buffer = gst_element_factory_make("rtpjitterbuffer", "audio_rtp_jitter_buffer");
-    g_object_set(audio_rtp_jitter_buffer, "mode", 1, "do-retransmission", TRUE, "drop-on-latency", TRUE, "latency", 1000, NULL);
+    g_object_set(audio_rtp_jitter_buffer, "mode", 1, "do-retransmission", TRUE, "drop-on-latency", TRUE, "latency", 100, NULL);
     GstElement *audio_depay = gst_element_factory_make("rtpopusdepay", "audio_depay");
     GstElement *audio_decode = gst_element_factory_make("opusdec", "audio_decode");
     GstElement *audio_convert = gst_element_factory_make("audioconvert", "audio_convert");
@@ -26,7 +26,7 @@ int main(int argc, char *argv[])
     GstElement *video_source = gst_element_factory_make("udpsrc", "video_source");
     g_object_set(video_source, "port", 7002, "caps", gst_caps_from_string("application/x-rtp"), NULL);
     GstElement *video_rtp_jitter_buffer = gst_element_factory_make("rtpjitterbuffer", "video_rtp_jitter_buffer");
-    g_object_set(video_rtp_jitter_buffer, "mode", 1, "do-retransmission", TRUE, "drop-on-latency", TRUE, "latency", 1000, NULL);
+    g_object_set(video_rtp_jitter_buffer, "mode", 1, "do-retransmission", TRUE, "drop-on-latency", TRUE, "latency", 100, NULL);
     GstElement *video_depay = gst_element_factory_make("rtph264depay", "video_depay");
     GstElement *video_decode = gst_element_factory_make("avdec_h264", "video_decode");
     GstElement *video_convert = gst_element_factory_make("videoconvert", "video_convert");

--- a/src/streaming/streaming-receiver.cpp
+++ b/src/streaming/streaming-receiver.cpp
@@ -15,6 +15,8 @@ int main(int argc, char *argv[])
     GstElement *pipeline = gst_pipeline_new("streaming");
     GstElement *audio_source = gst_element_factory_make("udpsrc", "audio_source");
     g_object_set(audio_source, "port", 7001, "caps", gst_caps_from_string("application/x-rtp"), NULL);
+    GstElement *audio_rtp_jitter_buffer = gst_element_factory_make("rtpjitterbuffer", "audio_rtp_jitter_buffer");
+    g_object_set(audio_rtp_jitter_buffer, "mode", 1, "do-retransmission", TRUE, "drop-on-latency", TRUE, "latency", 1000, NULL);
     GstElement *audio_depay = gst_element_factory_make("rtpopusdepay", "audio_depay");
     GstElement *audio_decode = gst_element_factory_make("opusdec", "audio_decode");
     GstElement *audio_convert = gst_element_factory_make("audioconvert", "audio_convert");
@@ -31,8 +33,8 @@ int main(int argc, char *argv[])
     GstElement *video_queue = gst_element_factory_make("queue", "video_queue");
     GstElement *video_sink = gst_element_factory_make("autovideosink", "video_sink");
 
-    gst_bin_add_many(GST_BIN(pipeline), audio_source, audio_depay, audio_decode, audio_convert, audio_queue, audio_sink, video_source, video_rtp_jitter_buffer, video_depay, video_decode, video_convert, video_queue, video_sink, NULL);
-    gst_element_link_many(audio_source, audio_depay, audio_decode, audio_convert, audio_queue, audio_sink, NULL);
+    gst_bin_add_many(GST_BIN(pipeline), audio_source, audio_rtp_jitter_buffer, audio_depay, audio_decode, audio_convert, audio_queue, audio_sink, video_source, video_rtp_jitter_buffer, video_depay, video_decode, video_convert, video_queue, video_sink, NULL);
+    gst_element_link_many(audio_source, audio_rtp_jitter_buffer, audio_depay, audio_decode, audio_convert, audio_queue, audio_sink, NULL);
     gst_element_link_many(video_source, video_rtp_jitter_buffer, video_depay, video_decode, video_convert, video_queue, video_sink, NULL);
 
     GstBus *bus = gst_pipeline_get_bus(GST_PIPELINE(pipeline));


### PR DESCRIPTION
- Without this element, audio will be delayed by 6-7 seconds.
- Currently the latency property of rtpjitterbuffer is set to 100 (ms), but if we want to tune it further we need to think carefully about the value of this property.